### PR TITLE
Add login feedback

### DIFF
--- a/apps/app/components/Login/index.js
+++ b/apps/app/components/Login/index.js
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Button, Form, Input, Typography } from "antd";
+import { Button, Form, Input, notification, Typography } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { useAuth } from "@coderdojobraga/ui";
 import Koi from "~/components/Koi";
@@ -19,7 +19,6 @@ function Login() {
       <Koi />
 
       <Title>Iniciar sessão</Title>
-
       <Form.Item
         name="email"
         rules={[
@@ -50,7 +49,7 @@ function Login() {
       <Form.Item
         className={styles.button}
         validateStatus={errors?.detail && "error"}
-        help={errors?.detail && "Autenticação inválida"}
+        help={!errors || "Autenticação inválida"}
       >
         <Button
           type="primary"

--- a/apps/app/components/Login/index.js
+++ b/apps/app/components/Login/index.js
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Button, Form, Input, notification, Typography } from "antd";
+import { Button, Form, Input, Typography, notification } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { useAuth } from "@coderdojobraga/ui";
 import Koi from "~/components/Koi";

--- a/packages/ui/components/Auth/AuthProvider.tsx
+++ b/packages/ui/components/Auth/AuthProvider.tsx
@@ -8,7 +8,7 @@ interface Props {}
 
 export function AuthProvider({ children }: PropsWithChildren<Props>) {
   const [user, setUser] = useState<undefined | IUser>();
-  const [errors, setErrors] = useState<undefined | IErrors>();
+  const [errors, setErrors] = useState<any | IErrors>();
   const [isLoading, setLoading] = useState<boolean>(false);
   const [isFirstLoading, setFirstLoading] = useState<boolean>(true);
 
@@ -28,7 +28,7 @@ export function AuthProvider({ children }: PropsWithChildren<Props>) {
       .then((user: any) => {
         setUser(user);
       })
-      .catch((error: any) => setErrors(error?.data?.errors))
+      .catch((error: any) => setErrors(error))
       .finally(() => setLoading(false));
   }
 


### PR DESCRIPTION
Currently if you get the login wrong (password or email), nothing is shown, just fails silently. This fixes it.