### PR TITLE
Mute badge errors

### DIFF
--- a/apps/app/components/Profile/index.tsx
+++ b/apps/app/components/Profile/index.tsx
@@ -52,7 +52,7 @@ function Profile({ id, role }: Props) {
       api
         .getNinjaBadges(id)
         .then((response) => setBadges(response.data))
-        .catch((error) => notification["error"](error.data?.errors));
+        .catch((error) => {});
 
       api
         .getNinjaFiles(id)


### PR DESCRIPTION
This is not a PR on how things should be done. But we are not using badges ATM, and we have bigger worries right now. In addition, the entire API error handling of the platform needs refactoring, so this is just a temporary fix.