### PR TITLE
Add social icons to register page

### DIFF
--- a/apps/app/components/Profile/index.tsx
+++ b/apps/app/components/Profile/index.tsx
@@ -24,7 +24,8 @@ import styles from "./style.module.css";
 import { EUser } from "bokkenjs";
 
 import { BsFileEarmarkPersonFill } from "react-icons/bs";
-import { SiPython, SiScratch } from "react-icons/si";
+
+import { getIcon } from "~/lib/utils";
 
 const { TabPane } = Tabs;
 const { Title } = Typography;
@@ -32,14 +33,6 @@ const { Title } = Typography;
 interface Props {
   id: string;
   role: EUser;
-}
-
-function getIcon(skill: string) {
-  if (skill.startsWith("Python")) {
-    return <SiPython />;
-  } else if (skill.startsWith("Scratch")) {
-    return <SiScratch />;
-  }
 }
 
 function Profile({ id, role }: Props) {

--- a/apps/app/components/Register/index.tsx
+++ b/apps/app/components/Register/index.tsx
@@ -28,6 +28,8 @@ import styles from "./style.module.css";
 import { useState } from "react";
 import { EUser } from "bokkenjs";
 
+import { getIcon } from "~/lib/utils";
+
 const { Option } = Select;
 
 const CountrySelect = () => (
@@ -227,7 +229,7 @@ function Register({ cities }: any) {
                                   key={item}
                                   value={item.toLocaleLowerCase()}
                                 >
-                                  {item}
+                                  {getIcon(item)} {item}
                                 </Option>
                               ))}
                             </Select>

--- a/apps/app/lib/utils.tsx
+++ b/apps/app/lib/utils.tsx
@@ -1,0 +1,35 @@
+import {
+  SiPython,
+  SiScratch,
+  SiCodewars,
+  SiGithub,
+  SiGitlab,
+  SiTrello,
+  SiDiscord,
+  SiSlack,
+} from "react-icons/si";
+
+export function getIcon(skill: string) {
+  if (skill.startsWith("Python")) {
+    return <SiPython />;
+  } else if (skill.startsWith("Scratch")) {
+    return <SiScratch />;
+  }
+
+  switch (skill) {
+    case "Scratch":
+      return <SiScratch />;
+    case "Codewars":
+      return <SiCodewars />;
+    case "GitHub":
+      return <SiGithub />;
+    case "GitLab":
+      return <SiGitlab />;
+    case "Trello":
+      return <SiTrello />;
+    case "Discord":
+      return <SiDiscord />;
+    case "Slack":
+      return <SiSlack />;
+  }
+}

--- a/apps/app/lib/utils.tsx
+++ b/apps/app/lib/utils.tsx
@@ -1,12 +1,12 @@
 import {
-  SiPython,
-  SiScratch,
   SiCodewars,
+  SiDiscord,
   SiGithub,
   SiGitlab,
-  SiTrello,
-  SiDiscord,
+  SiPython,
+  SiScratch,
   SiSlack,
+  SiTrello,
 } from "react-icons/si";
 
 export function getIcon(skill: string) {

--- a/apps/app/pages/settings.tsx
+++ b/apps/app/pages/settings.tsx
@@ -35,14 +35,8 @@ import {
 } from "bokkenjs";
 import { withAuth } from "~/components/Auth";
 import AppLayout from "~/layouts/AppLayout";
-import { SiPython } from "react-icons/si";
-import { SiScratch } from "react-icons/si";
-import { SiCodewars } from "react-icons/si";
-import { SiGithub } from "react-icons/si";
-import { SiGitlab } from "react-icons/si";
-import { SiTrello } from "react-icons/si";
-import { SiDiscord } from "react-icons/si";
-import { SiSlack } from "react-icons/si";
+
+import { getIcon } from "~/lib/utils";
 
 const { Title } = Typography;
 const { Option } = Select;
@@ -54,31 +48,6 @@ const Section = ({ title }: { title: string }) => (
     </Title>
   </Divider>
 );
-
-function getIcon(skill: string) {
-  if (skill.startsWith("Python")) {
-    return <SiPython />;
-  } else if (skill.startsWith("Scratch")) {
-    return <SiScratch />;
-  }
-
-  switch (skill) {
-    case "Scratch":
-      return <SiScratch />;
-    case "Codewars":
-      return <SiCodewars />;
-    case "GitHub":
-      return <SiGithub />;
-    case "GitLab":
-      return <SiGitlab />;
-    case "Trello":
-      return <SiTrello />;
-    case "Discord":
-      return <SiDiscord />;
-    case "Slack":
-      return <SiSlack />;
-  }
-}
 
 function Settings() {
   const { user, edit_user, isLoading } = useAuth();


### PR DESCRIPTION
Added the same icons used on the settings and profile views for the socials to the dropdown on the register page too. Also created a new "utils.tsx" on /lib so I can use the `getIcon()` function on multiple components.

![Screenshot from 2022-12-16 15-13-50](https://user-images.githubusercontent.com/80540164/208129381-cd50bada-986c-44df-98a0-63d21d33e971.png)
