### PR TITLE
Improve blog legibility

### DIFF
--- a/apps/blog/_posts/choosing-first-language.md
+++ b/apps/blog/_posts/choosing-first-language.md
@@ -12,30 +12,22 @@ featured: false
 
 ---
 
-&nbsp;
-
 Esta é das decisões mais importantes para o desenrolar da sua jornada pelo mundo da programação, e também das mais difíceis, sobretudo para quem não tem experiência na área, dado o enorme número de alternativas disponíveis.
 
 As diferentes linguagens correspondem a diferentes ferramentas, pelo que é essencial escolher uma que se adeque aos objetivos do ninja - ou seja, o porquê de querer aprender a programar ou o tipo de projetos que quer desenvolver -, mas também às suas capacidades de raciocínio.
 
 Aqui ficam as nossas sugestões, todas elas disponíveis para o ninja aprender no seu percurso no CoderDojo Braga.
 
-&nbsp;
-
 ## Scratch
 
 Desenvolvido em 2007 pelo MIT, o [Scratch](https://scratch.mit.edu/) foi criado com o objetivo de introduzir crianças ao mundo da programação. Trata-se de uma linguagem de programação visual, o que significa que o ninja não escreve diretamente o código do seu projeto. Em vez disso, o ninja arrasta diferentes blocos para construir a sua aplicação, como se de um puzzle se tratasse. Esta interface permite aos ninjas criar as suas próprias histórias, animações e jogos.
 No CoderDojo Braga, o Scratch é a plataforma de eleição para ensinar os ninjas mais novos, antes de os introduzir a uma linguagem textual.
-
-&nbsp;
 
 ## Python
 
 Python é uma linguagem textual bastante versátil, permitindo o desenvolvimento de aplicações desde jogos 2D e 3D, servidores web, programas para telemóvel, e até aplicações mais avançadas que usem inteligência artificial.
 
 A sua sintaxe é das mais simples que existem atualmente, o que torna Python uma excelente primeira linguagem textual. Exatamente por esse motivo, é a linguagem por excelência ensinada no CoderDojo Braga, recomendada para os ninjas mais velhos.
-
-&nbsp;
 
 ## HTML/CSS/Javascript
 
@@ -45,14 +37,10 @@ HTML e CSS são linguagens que oferecem desafios bastante diferentes das linguag
 
 À semelhança de Python, tratam-se de linguagens textuais, pelo que são recomendadas apenas para ninjas mais velhos / avançados que tenham interesse em desenvolvimento de websites.
 
-&nbsp;
-
 ## C
 
 De todas as linguagens mencionadas até aqui, C é a mais difícil de aprender. Por esse motivo, aconselhamos apenas para ninjas bastante avançados. C é particularmente útil para desenvolvimento de software para microcontroladores, como Arduinos, por exemplo; ou desenvolvimento de sistemas operativos.
 Assim sendo, apenas recomendamos C se um destes tópicos for do interesse do ninja, uma vez que o grau acrescido de dificuldade não compensa se o intuito do ninja for desenvolver aplicações.
-
-&nbsp;
 
 Qualquer que seja a linguagem a aprender, o importante é o ninja gostar do que está a fazer. Aprender a programar é um processo demorado, e estar motivado é essencial para o seu sucesso.
 

--- a/apps/blog/_posts/difference-languages.md
+++ b/apps/blog/_posts/difference-languages.md
@@ -10,11 +10,7 @@ topic: "Linguagens"
 featured: "true"
 ---
 
-&nbsp;
-
 Quando falamos sobre programação temos a ideia que vamos aprender diferentes linguagens de programação, mas na realidade o que estamos a aprender são diferentes paradigmas. Um paradigma é uma forma que existe de classificar uma linguagem baseada nas suas funcionalidades. A escolha desse paradigma vai influenciar toda a estrutura e execução do programa.
-
-&nbsp;
 
 ## Paradigma Funcional
 
@@ -23,14 +19,10 @@ Este paradigma é o mais similar à matemática, sendo assim a única barreira d
 
 O Paradigma Funcional é usado em várias linguagens, como por exemplo [Haskell](https://www.youtube.com/watch?v=Qa8IfEeBJqk) e [Elixir](https://www.youtube.com/watch?v=R7t7zca8SyM), são populares porque permitem aos programadores criar e manter software com funções pequenas e limpas, o que é vital para organização de código.
 
-&nbsp;
-
 ## Paradigma Imperativo
 
 O Paradigma Imperativo é o mais antigo da computação, este consiste em numa característica central a definição sequencial de instruções que representam uma modificação no estado do programa. O Paradigma Imperativo centra-se muito na [arquitetura de Von Neumann’s](https://www.youtube.com/watch?v=tZ5W2LpdcEw) , ou seja, a memória armazena informações e instruções do programa que podem ser alterados a partir de operações aritméticas ou atribuidos a variáveis.
 As linguagens mais conhecidas neste paradigma são por exemplo [C](https://www.youtube.com/watch?v=U3aXWizDbQ4) e [Rust](https://www.youtube.com/watch?v=5C_HPTJg5ek)
-
-&nbsp;
 
 ## Paradigma Orientado a Objetos
 
@@ -49,26 +41,18 @@ Um exemplo:
 
 As linguagens mais usadas quando nos referimos a este paradigma são [Java](https://www.youtube.com/watch?v=l9AzO1FMgM8) e [C#](https://www.youtube.com/watch?v=ravLFzIguCM), apesar das suas vantagens este tipo de paradigma têm os seus contras que são performances lentas e um grande espaço de memôria necessário quando críamos aplicações.
 
-&nbsp;
-
 ## Paradigma Orientado a Eventos
 
 O Paradigma Orientado a Eventos é um paradigma onde as entendidades (objetivos, serviços, etc) comunicam indiretamente através de mensagens que são enviadas pelo um intermediário. Por norma estas mensagens são guardadas numa [fila de espera](https://www.youtube.com/watch?v=QCb6k2nik5k) antes de serem usadas. Por norma a execução do programa é determinada por novos "eventos" do usuário.
 Mas o que são esses eventos? São por exemplo cliques no botão do rato, ou em teclas, mover o rato para umas coordenadas do mapa.
 A linguagem mais conhecida e mais usada neste paradigma é o [Scratch](https://www.youtube.com/watch?v=B1JoK3Vgd_w) e por norma é usada para introduzir crianças e jovens à programação de uma forma lúdica e divertida.
 
-&nbsp;
-
 ## MultiParadigmas
 
 Multi paradigmas acontecem quando uma linguagem não fica restrita apenas a um paradigma e consegue ser usadas de diferentes formas, ou seja, consegue ser funcional ou seja trabalhar apenas com [recursividade](https://www.youtube.com/watch?v=NKymAD4pJZI) e ao mesmo tempo imperativa tendo variáveis e instruções na memória.
 Um bom exemplo de linguagem que é um multiparadigma é o [Python](https://www.youtube.com/watch?v=x7X9w_GIm1s) e o [Javascript](https://www.youtube.com/watch?v=DHjqpvDnNGE).
 
-&nbsp;
-
 ## Mas afinal qual é o melhor paradigma?
 
 A realidade é que não existe um paradigma melhor, cada paradigma têm um estrutura diferente para desenvolver um projeto, cada um têm as suas vantagens e desvantagens como referido previamente, tentem procurar a melhor [stack](https://blog.betrybe.com/tecnologia/stack-tecnologico/) possível para desenvolverem o vosso projeto que seja eficiente e favorável ao que querem fazer, procurem projetos semelhantes e procurem perceber porque é que uma certa [stack](https://blog.betrybe.com/tecnologia/stack-tecnologico/) foi usada por o/a programador/equipa.
 Pessoalmente, eu prefiro desenvolver com uma [stack](https://blog.betrybe.com/tecnologia/stack-tecnologico/) que use um/uma paradigma/linguagem funcional devido às razões apresentadas previamente e porque torna possível desenvolver bons projetos com relativamente poucas linhas relativamente à dimensão do projeto, ou seja, caso seja um projeto com um tamanho astronómico torna-se impossível de desenvolver com meia dúzia de linhas, mas acabamos sempre por escrever menos quando comparado com outras linguagens.
-
-&nbsp;

--- a/apps/blog/_posts/jess-2022.md
+++ b/apps/blog/_posts/jess-2022.md
@@ -12,31 +12,19 @@ featured: true
 
 ---
 
-&nbsp;
-
 Eu sou a Jéssica, e este ano sou a champion do CoderDojo Braga!
-
-&nbsp;
 
 É o meu terceiro ano de CoderDojo e tem sido uma experiência mais que incrível ter a honra de poder fazer parte de uma iniciativa tão altruísta e enriquecedora.
 
-&nbsp;
-
 É um privilégio ser a primeira Champion mulher do CoderDojo Braga, principalmente num ano tão especial em que celebramos o seu 10º aniversário.
-
-&nbsp;
 
 Posso dizer que o CoderDojo é um projeto ao qual se nos dedicarmos verdadeiramente, recebemos tanto em troca que é impossível não nos transformar.
 É muito trabalho e dedicação para que tudo funcione com a melhor qualidade possível para os nossos ninjas. Por vezes, é difícil e cansativo, mas não duvido por um segundo que vale
 a pena. Ver as crianças felizes e entusiasmadas a aprender é a melhor recompensa ao nosso esforço, além da experiência que adquirimos, e o quanto crescemos no processo.
 Este ano estamos a investir com todos os recursos que temos na divulgação do CoderDojo, no recrutamento e formação.
 
-&nbsp;
-
 A nossa maior novidade é a nossa plataforma que vai inovar a forma como trabalhamos. O foco é aumentar consideravelmente o número de mentores para conseguirmos atender o máximo de crianças
 possíveis, e, talvez até levar as nossas sessões a outros lugares.
 Uma das nossas maiores ambições é ter uma equipa grande o suficiente para realizar um projeto há muito desejado: o Summer Camp do CoderDojo, uma espécie de semana aberta nas férias de verão.
-
-&nbsp;
 
 Será um ano de mudança, de muito trabalho, e acima de tudo, acredito que de muito sucesso e aprendizagem para todos.

--- a/apps/blog/_posts/tech-post-1.md
+++ b/apps/blog/_posts/tech-post-1.md
@@ -12,11 +12,7 @@ featured: false
 
 ---
 
-&nbsp;
-
 Este é o primeiro post de uma série em que vamos discutir as plataformas do CoderDojo Braga. Como foram feitas, dificuldades técnicas, histórias engraçadas e o seu futuro são alguns dos temas que podem esperar daqui. Espero sinceramente que, antes de um blog técnico, isto seja um blog educativo, e que demonstre o trabalho necessário para fazer uma aplicação que vai ser usada por várias pessoas, trazendo assim uma maior sensibilidade para a engenharia de software.
-
-&nbsp;
 
 ## O nascimento
 
@@ -41,8 +37,6 @@ Este post está a ser escrito em [Markdown](https://markdownguide.org), e precis
 
 A outra funcionalidade que se destacou, e esta não foi implementada por mim (créditos ao [Daniel Pereira](https://github.com/danielsp45)), foi o algoritmo de emparelhamento entre ninjas e mentores antes de uma sessão. Foi uma tarefa bastante complexa do ponto de vista algorítmico, e foi resolvida implementando o [algoritmo húngaro](https://en.wikipedia.org/wiki/Hungarian_algorithm)
 
-&nbsp;
-
 ## Publicação
 
 Com a plataforma desenvolvida, chega o momento de a publicar. Como há dois projetos desenvolvidos, é preciso publicar a plataforma em duas frentes. O site em si foi publicado no [Netlify](https://www.netlify.com/). O processo é bastante simples, basta ligar o Netlify ao repositório no Github que o site é publicado praticamente instantaneamente. Exceto que é preciso fazer isso 3 vezes. Porquê 3 vezes? Porque o site está, na verdade, dividido em 3 subsites: a página web, o blog e a aplicação, cada um a ter de ser publicado em separado. Isto causou algumas frustrações com reencaminhamentos entre os 3 subsites, mas isso é história para outro dia.
@@ -50,8 +44,6 @@ Com a plataforma desenvolvida, chega o momento de a publicar. Como há dois proj
 O backend, por seu lado, foi publicado num servidor do Departamento de Informática, através de containers [Docker](https://www.docker.com/). Isto traz-nos responsabilidade acrescida, pois somos nós os responsáveis por fazer os backups dos dados.
 
 Finalmente, o último passo é configurar o [DNS](https://pt.wikipedia.org/wiki/Sistema_de_Nomes_de_Dom%C3%ADnio), que, no nosso caso, faz-se no [Namecheap](https://www.namecheap.com/).
-
-&nbsp;
 
 ## E agora?
 

--- a/apps/blog/components/Markdown/style.module.css
+++ b/apps/blog/components/Markdown/style.module.css
@@ -39,7 +39,7 @@
 }
 
 .markdown {
-  max-width: 1536px;
+  max-width: 700px;
   /*width: 100vw!important;*/
   height: auto;
   margin: auto;
@@ -47,16 +47,22 @@
 }
 
 .markdown h1 {
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
   font-size: 2.5rem !important;
   font-weight: bold;
 }
 
 .markdown h2 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
   font-size: 2rem !important;
   font-weight: bold;
 }
 
 .markdown h3 {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
   font-size: 1.5rem !important;
   font-weight: bold;
 }
@@ -72,13 +78,22 @@
 
 .markdown ul {
   list-style: disc;
+  margin-block: 0.5rem;
+  padding-inline-start: 2rem;
 }
 
 .markdown ol {
   list-style: decimal;
+  margin-block: 0.5rem;
+  padding-inline-start: 2rem;
+}
+
+.markdown li {
+  margin-block: 0.5rem;
 }
 
 .markdown p {
+  margin-block: 0.5rem;
   font-size: 1rem;
   font-weight: normal;
 }
@@ -98,4 +113,26 @@
 .markdown img {
   max-width: 100%;
   height: auto;
+}
+
+.markdown blockquote {
+  margin-block: 0.75rem;
+  padding: 1rem;
+  background-color: rgb(248, 248, 248);
+  border-radius: 5px;
+  border-left: 5px solid rgb(148, 148, 148);
+}
+
+.dark blockquote {
+  background-color: rgb(41, 41, 41);
+  border-radius: 5px;
+  border-left: 5px solid rgb(97, 97, 97);
+}
+
+.markdown blockquote>p {
+  margin: 0;
+}
+
+.markdown hr {
+  margin-block: 2rem;
 }

--- a/apps/blog/components/Post/index.tsx
+++ b/apps/blog/components/Post/index.tsx
@@ -15,7 +15,7 @@ const Post = ({ title, author, date, content }: Props) => {
     >
       <div className="m-16">
         <div className="mb-16">
-          <h1 className="my-4 block text-6xl font-bold dark:text-white">
+          <h1 className="my-4 block text-5xl font-bold dark:text-white">
             {title}
           </h1>
 


### PR DESCRIPTION
I noticed while I was writing a post for the blog that the text looked a bit cramped, so I tried improving it. 

Main changes:
- reduced line lengths to make text more legible
- added blockquote styling
- added margin to headers to avoid the need for `&nbsp;`

Screenshots:

<details><summary>Title and main content</summary>
Before:

![cdb-head-before](https://user-images.githubusercontent.com/46627071/214332215-c8c2b964-105b-4e4e-935c-c58a08fb2b16.png)

After: 

![cdb-head-after](https://user-images.githubusercontent.com/46627071/214332335-9ac46ca7-76eb-4ca8-a4f7-e2063f02e670.png)

</details>

<details><summary>Lists and blockquotes</summary>
Before:

![cdb-content-before](https://user-images.githubusercontent.com/46627071/214332552-91469377-0a00-47ea-9d98-0dd5332ea86e.png)

After: 

![cdb-content-after](https://user-images.githubusercontent.com/46627071/214332572-a51a1168-7bb8-4621-a2ca-5a4bcededda3.png)

</details>