### PR TITLE
Improve team page performance

### DIFF
--- a/apps/web/components/Member/index.tsx
+++ b/apps/web/components/Member/index.tsx
@@ -1,9 +1,15 @@
-export default function Member({ picture, name, role }) {
+import Image from "next/image";
+
+import { ITeamMember } from "~/lib/types";
+
+export default function Member({ name, picture, role }: ITeamMember) {
   return (
     <div className="w-12/12 xl:w-2/10 mx-auto mb-12 mt-12 px-4 sm:w-6/12 md:w-4/12 lg:mb-0 lg:w-3/12 2xl:w-2/12">
-      <img
+      <Image
         alt={name}
-        src={`img/team/${picture}`}
+        src={`/img/team/${picture}`}
+        width={400}
+        height={400}
         className="mx-auto h-56 w-56 rounded-full object-cover shadow-lg md:h-48 md:w-48"
       />
       <div className="p-4 text-center">

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -15,3 +15,9 @@ export interface IBelt {
   image: string;
   requirements: string[];
 }
+
+export interface ITeamMember {
+  picture: string;
+  name: string;
+  role: string;
+}

--- a/apps/web/pages/team.tsx
+++ b/apps/web/pages/team.tsx
@@ -1,9 +1,9 @@
 import { Footer, Header } from "@coderdojobraga/ui";
 import Member from "~/components/Member";
 
-import team from "~/data/team.json";
+import { ITeamMember } from "~/lib/types";
 
-export default function Team() {
+export default function Team({ team }: { team: ITeamMember[] }) {
   return (
     <>
       <Header landing={true} />
@@ -38,4 +38,20 @@ export default function Team() {
       <Footer bgColor="white" fgColor="dark" />
     </>
   );
+}
+
+import fsPromises from "fs/promises";
+import path from "path";
+
+export async function getStaticProps() {
+  const filePath = path.join(process.cwd(), "data", "team.json");
+  const jsonData = await fsPromises.readFile(filePath, "utf-8");
+  const parsedData = JSON.parse(jsonData);
+
+  return {
+    props: {
+      team: parsedData,
+    },
+    revalidate: 3600, // 1 hour in seconds
+  };
 }


### PR DESCRIPTION
Team page had a problem regarding image loading - it was taking too much time between re-renders.
Taking benefit of `getStaticProps` and the optimized `Image` component from Next.js, we can largely improve the page performance.