### PR TITLE
Add X-frame options to Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"


### PR DESCRIPTION
This will make sure our web pages can not be displayed inside `<iframe>` or `<embed>`, making us not vulnerable to Clickjacking attacks.