### PR TITLE
refactor: enhance ninjas page

### DIFF
--- a/apps/app/components/Ninja/index.js
+++ b/apps/app/components/Ninja/index.js
@@ -1,29 +1,58 @@
-import { Avatar, Card } from "antd";
+import React, { useState } from "react";
+import { Avatar, Button, Card, Popconfirm, Space } from "antd";
 import { EditOutlined } from "@ant-design/icons";
 import Belt from "~/components/Belt";
 import Link from "next/link";
+import NinjaForm from "~/components/NinjaForm";
 
 const { Meta } = Card;
 
 function Ninja(ninja) {
+  const [showNinjaForm, setShowNinjaForm] = useState(false);
+  const [showPopconfirm, setShowPopconfirm] = useState(false);
+
+  const handleButtonClick = () => {
+    setShowNinjaForm(false);
+    setShowPopconfirm(true);
+  };
+
+  const handleConfirm = () => {
+    setShowNinjaForm(true);
+    setShowPopconfirm(false);
+  };
+
+  const handleCancel = () => {
+    setShowPopconfirm(false);
+  };
+
   return (
     <Card
       key={ninja.id}
       size="large"
       style={{ width: 300, marginTop: 16 }}
       actions={[
-        <Link key={`link ${ninja.id}`} href={`/ninjas/edit/${ninja.id}`}>
-          <a>
-            <EditOutlined key="edit" />
-          </a>
-        </Link>,
+        <Popconfirm
+          key={`popconfirm ${ninja.id}`}
+          title="Tem certeza que deseja editar?"
+          open={showPopconfirm}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        >
+          <Button
+            key={`button ${ninja.id}`}
+            icon={<EditOutlined />}
+            onClick={handleButtonClick}
+          />
+        </Popconfirm>,
       ]}
     >
+      {showNinjaForm && <NinjaForm id={ninja.id} reloadNinjas={null} />}
       <Link href={`/profile/ninja/${ninja.id}`}>
         <a>
           <Meta
             avatar={<Avatar src={ninja.photo} />}
             title={`${ninja.first_name} ${ninja.last_name}`}
+            style={{ marginBottom: "10px" }}
           />
           <Belt belt={ninja.belt} />
         </a>

--- a/apps/app/pages/ninjas/index.tsx
+++ b/apps/app/pages/ninjas/index.tsx
@@ -1,39 +1,73 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Button, Col, Row, Typography } from "antd";
-import { PlusOutlined } from "@ant-design/icons";
+import { Button, Col, Popconfirm, Row, Typography } from "antd";
+import { PlusCircleFilled, PlusOutlined } from "@ant-design/icons";
 import { withAuth } from "~/components/Auth";
 import AppLayout from "~/layouts/AppLayout";
 import * as api from "bokkenjs";
+import NinjaForm from "~/components/NinjaForm";
 import Ninja from "~/components/Ninja";
 import { notifyError } from "~/components/Notification";
+import { set } from "lodash-es";
 
 const { Title } = Typography;
 
 function Ninjas() {
   const [ninjas, setNinjas] = useState<any[]>([]);
+  const [showNinjaForm, setShowNinjaForm] = useState(false);
+  const [showPopconfirm, setShowPopconfirm] = useState(false);
 
-  useEffect(() => {
+  const fetchNinjas = () => {
     api
       .getNinjas()
       .then((response: any) => setNinjas(response.data))
       .catch((error) => {
         notifyError("Ocorreu um erro", "Não foi possível obter os seus ninjas");
       });
+  };
+
+  useEffect(() => {
+    fetchNinjas();
   }, []);
+
+  const handleButtonClick = () => {
+    setShowNinjaForm(false);
+    setShowPopconfirm(true);
+  };
+
+  const handleConfirm = () => {
+    setShowNinjaForm(true);
+    setShowPopconfirm(false);
+  };
+
+  const handleCancel = () => {
+    setShowPopconfirm(false);
+  };
 
   return (
     <AppLayout>
       <Row justify="space-between">
         <Title level={2}>Os Meus Ninjas</Title>
-        <Link href="/ninjas/new">
+        <Popconfirm
+          title="Quer criar um Ninja?"
+          open={showPopconfirm}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          okText="Sim"
+          cancelText="Não"
+          placement="left"
+        >
           <Button
-            shape="circle"
+            shape="default"
             type="primary"
             size="large"
             icon={<PlusOutlined />}
+            onClick={handleButtonClick}
           />
-        </Link>
+        </Popconfirm>
+        {showNinjaForm && (
+          <NinjaForm id={undefined} reloadNinjas={() => fetchNinjas()} />
+        )}
       </Row>
       <Row justify="space-around" gutter={[10, 10]}>
         {ninjas.map((ninja: any) => (


### PR DESCRIPTION
This PR intends to improve the entire user experience of the target audience (Guardians). I moved the editing and creation of Ninjas from new pages to a single modal that keeps the route in use. I also standardized the Ninjas page to match the rest of the application with "default" components. At this point, it is still necessary to correct the "invalid date" in the Ninjas edition, which arises from the fact that the .birthday property is not included in the response data. I await correction from the backend to make the changes fully functional.