### PR TITLE
fix: align socials select component

### DIFF
--- a/apps/app/pages/settings.tsx
+++ b/apps/app/pages/settings.tsx
@@ -343,7 +343,15 @@ function Settings() {
                                 key={item}
                                 value={item.toLocaleLowerCase()}
                               >
-                                {getIcon(item)} {item}
+                                <div
+                                  style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: "5px",
+                                  }}
+                                >
+                                  {getIcon(item)} {item}
+                                </div>
                               </Option>
                             ))}
                           </Select>


### PR DESCRIPTION
Fixes an odd alignment behavior with the socials select component.

<img width="329" alt="image" src="https://github.com/coderdojobraga/shuriken/assets/30907944/d7fc6b27-fd2d-40c3-a8e1-79805efff1b4">

<img width="322" alt="image" src="https://github.com/coderdojobraga/shuriken/assets/30907944/842b196d-ec14-4ef8-ac8b-7abc3bcd0eed">
